### PR TITLE
Add unit tests for full coverage

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,0 +1,51 @@
+from langchain_core.messages import HumanMessage, AIMessage
+from src.worker_manager import WorkerManager
+from src.state_manager import StateManager
+from src.models import WorkerNode, TaskPlan, ExecutionWaves
+from pydantic import BaseModel
+
+class DummyModel(BaseModel):
+    messages: list = []
+
+def dummy_func(state):
+    return {}
+
+def setup_manager():
+    wm = WorkerManager()
+    node = WorkerNode(function=dummy_func, model=DummyModel, state_placeholder="s1", description="d", name="n1")
+    wm.add_node(node)
+    return wm, node
+
+def test_prepare_command_output_first_wave():
+    wm, node = setup_manager()
+    sm = StateManager(wm)
+    exec_waves = ExecutionWaves(waves={0: [TaskPlan(task_id="1", task="t1", node_allocated="n1")]})
+    state = type("S", (), {
+        "current_wave": 0,
+        "task_results": {},
+        "execution_waves": exec_waves,
+        "s1": DummyModel(messages=[AIMessage(content="r")]),
+    })()
+    out = sm.prepare_command_output(state)
+    assert out == {"current_wave": 1, "task_results": {}}
+
+def test_prepare_command_output_subsequent_wave():
+    wm, node = setup_manager()
+    sm = StateManager(wm)
+    exec_waves = ExecutionWaves(waves={0: [TaskPlan(task_id="1", task="t1", node_allocated="n1")]})
+    state = type("S", (), {
+        "current_wave": 1,
+        "task_results": {},
+        "execution_waves": exec_waves,
+        "s1": DummyModel(messages=[HumanMessage(content="task")]),
+    })()
+    out = sm.prepare_command_output(state)
+    assert out["current_wave"] == 2
+    assert out["task_results"] == {"t1": "task"}
+
+def test_create_dynamic_state():
+    wm, node = setup_manager()
+    sm = StateManager(wm)
+    Dynamic = sm.create_dynamic_state()
+    field_names = Dynamic.__fields__.keys()
+    assert "s1" in field_names

--- a/tests/test_wave_manager.py
+++ b/tests/test_wave_manager.py
@@ -1,0 +1,41 @@
+from src.worker_manager import WorkerManager
+from src.wave_manager import WaveManager
+from src.models import WorkerNode, TaskPlan, ExecutionWaves
+from pydantic import BaseModel
+
+class DummyModel(BaseModel):
+    messages: list = []
+
+def dummy_func(state):
+    return {}
+
+
+def build_wave_manager():
+    wm = WorkerManager()
+    node1 = WorkerNode(function=dummy_func, model=DummyModel, state_placeholder="s1", description="d1", name="n1")
+    node2 = WorkerNode(function=dummy_func, model=None, state_placeholder="s2", description="d2", name="n2")
+    wm.add_node(node1)
+    wm.add_node(node2)
+    return WaveManager(wm), wm
+
+def test_create_execution_waves():
+    wave_manager, wm = build_wave_manager()
+    tasks = [
+        TaskPlan(task_id="1", task="t1", node_allocated="n1"),
+        TaskPlan(task_id="2", task="t2", node_allocated="n2"),
+        TaskPlan(task_id="3", task="t3", node_allocated="n1"),
+    ]
+    waves = wave_manager.create_execution_waves(tasks)
+    assert waves.waves[0][0].task_id == "1"
+    assert waves.waves[0][1].task_id == "2"
+    assert waves.waves[1][0].task_id == "3"
+
+def test_is_waves_complete_and_get_current_tasks():
+    wave_manager, wm = build_wave_manager()
+    exec_waves = ExecutionWaves(waves={0: [TaskPlan(task_id="1", task="t", node_allocated="n1")]})
+    state = type("S", (), {"current_wave": 0, "execution_waves": exec_waves})()
+    assert not wave_manager.is_waves_complete(state)
+    tasks = wave_manager.get_current_wave_tasks(state)
+    assert tasks[0].task_id == "1"
+    state.current_wave = 1
+    assert wave_manager.is_waves_complete(state)

--- a/tests/test_wave_orchestrator.py
+++ b/tests/test_wave_orchestrator.py
@@ -1,0 +1,112 @@
+from langchain_core.messages import HumanMessage, AIMessage
+from src.models import WorkerNode, TaskPlan
+from src.wave_orchestrator import WaveOrchestrator
+from pydantic import BaseModel
+
+class DummyLLM:
+    def __init__(self):
+        self.invoked = []
+    def invoke(self, prompt):
+        self.invoked.append(prompt)
+        return AIMessage(content="ok")
+    def with_structured_output(self, model):
+        class Wrapper:
+            def __init__(self, outer):
+                self.outer = outer
+            def invoke(self, prompt):
+                # return simple valid object
+                return model(task_plans=[TaskPlan(task_id="1", task="t", node_allocated="n1")])
+        return Wrapper(self)
+
+class DummyModel(BaseModel):
+    messages: list = []
+
+def dummy_func(state):
+    return {"dummy": True}
+
+def setup_orchestrator():
+    orch = WaveOrchestrator(llm=DummyLLM())
+    node = WorkerNode(function=dummy_func, model=DummyModel, state_placeholder="s1", description="d", name="n1")
+    orch.add_node(node)
+    return orch
+
+def test_create_answering_node():
+    orch = setup_orchestrator()
+    node_fn = orch.create_answering_node()
+    state = type("S", (), {"task_results": {"a": "b"}, "messages": [HumanMessage(content="q")]} )()
+    cmd = node_fn(state)
+    assert cmd.goto == "__end__"
+    assert isinstance(cmd.update["messages"][-1], AIMessage)
+
+
+def test_create_sequential_plan_node():
+    orch = setup_orchestrator()
+    plan_fn = orch.create_sequential_plan_node()
+    state = type("S", (), {"messages": [HumanMessage(content="q")]} )()
+    cmd = plan_fn(state)
+    assert cmd.goto == "progress"
+    assert cmd.update["execution_waves"].waves
+
+
+def test_create_sequential_progress_node_and_compile():
+    orch = setup_orchestrator()
+    # create simple plan manually
+    tasks = [TaskPlan(task_id="1", task="t", node_allocated="n1")]
+    orch.wave_manager = orch.wave_manager  # ensure wave_manager exists
+    exec_waves = orch.wave_manager.create_execution_waves(tasks)
+    state = type("S", (), {
+        "messages": [],
+        "task_plans": tasks,
+        "task_results": {},
+        "execution_waves": exec_waves,
+        "current_wave": 0,
+    })()
+    progress_fn = orch.create_sequential_progress_node()
+    cmd = progress_fn(state)
+    assert cmd.goto == ["n1"]
+    assert "s1" in cmd.update
+    compiled = orch.compile()
+    assert compiled
+
+
+def test_progress_node_when_complete_and_no_model():
+    orch = WaveOrchestrator(llm=DummyLLM())
+    node = WorkerNode(function=dummy_func, model=None, state_placeholder="s0", description="d", name="n0")
+    orch.add_node(node)
+    tasks = [TaskPlan(task_id="1", task="t", node_allocated="n0")]
+    exec_waves = orch.wave_manager.create_execution_waves(tasks)
+    state = type(
+        "S", (), {
+            "messages": [],
+            "task_plans": tasks,
+            "task_results": {},
+            "execution_waves": exec_waves,
+            "s0": DummyModel(messages=[AIMessage(content="r")]),
+            "current_wave": len(exec_waves.waves),
+        }
+    )()
+    progress_fn = orch.create_sequential_progress_node()
+    cmd = progress_fn(state)
+    assert cmd.goto == "answering"
+
+
+def test_progress_node_without_model_branch():
+    orch = WaveOrchestrator(llm=DummyLLM())
+    node = WorkerNode(function=dummy_func, model=None, state_placeholder="s0", description="d", name="n0")
+    orch.add_node(node)
+    tasks = [TaskPlan(task_id="1", task="t", node_allocated="n0")]
+    exec_waves = orch.wave_manager.create_execution_waves(tasks)
+    state = type(
+        "S", (), {
+            "messages": [],
+            "task_plans": tasks,
+            "task_results": {},
+            "execution_waves": exec_waves,
+            "s0": DummyModel(messages=[AIMessage(content="r")]),
+            "current_wave": 0,
+        }
+    )()
+    progress_fn = orch.create_sequential_progress_node()
+    cmd = progress_fn(state)
+    assert cmd.goto == ["n0"]
+    assert "s0" in cmd.update

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -1,0 +1,46 @@
+import pytest
+from src.worker_manager import WorkerManager
+from src.models import WorkerNode, TaskPlan
+from pydantic import BaseModel
+
+class DummyModel(BaseModel):
+    messages: list = []
+
+def dummy_func(state):
+    return {"done": True}
+
+def build_manager():
+    wm = WorkerManager()
+    node1 = WorkerNode(function=dummy_func, model=DummyModel, state_placeholder="s1", description="node one", name="n1")
+    node2 = WorkerNode(function=dummy_func, model=None, state_placeholder="s2", description="node two", name="n2")
+    wm.add_node(node1)
+    wm.add_node(node2)
+    return wm, node1, node2
+
+def test_add_and_describe_nodes():
+    wm, node1, node2 = build_manager()
+    assert wm.workers == ["n1", "n2"]
+    assert wm.worker_descriptions["n1"] == "node one"
+    assert wm.workers_nodes["n2"] is node2
+
+def test_get_worker_list_description():
+    wm, _, _ = build_manager()
+    desc = wm.get_worker_list_description()
+    assert "**n1**: node one" in desc and "**n2**: node two" in desc
+
+def test_get_dynamic_fields():
+    wm, node1, node2 = build_manager()
+    fields = wm.get_dynamic_fields()
+    assert list(fields.keys()) == ["s1"]
+    assert DummyModel in getattr(fields["s1"][0], "__args__", [])
+
+def test_get_tasks_per_nodes():
+    wm, node1, node2 = build_manager()
+    tasks = [
+        TaskPlan(task_id="1", task="t1", node_allocated="n1"),
+        TaskPlan(task_id="2", task="t2", node_allocated="n2"),
+        TaskPlan(task_id="3", task="t3", node_allocated="n1"),
+    ]
+    per_node = wm.get_tasks_per_nodes(tasks)
+    assert [t.task_id for t in per_node["n1"]] == ["1", "3"]
+    assert [t.task_id for t in per_node["n2"]] == ["2"]


### PR DESCRIPTION
## Summary
- add comprehensive unit tests for worker, wave, state managers and orchestrator
- ensure imports via tests package init
- reach 100% test coverage

## Testing
- `pytest --cov=src -q`

------
https://chatgpt.com/codex/tasks/task_e_68641751f530832b960e5c83bbd63210