### PR TITLE
Add environment variable example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Copy this file to .env and fill in your credentials
+
+# OpenAI API key for ChatOpenAI
+OPENAI_API_KEY=your-openai-api-key
+
+# Optional: enable LangSmith tracing
+LANGCHAIN_TRACING_V2=true
+LANGCHAIN_API_KEY=your-langsmith-api-key
+
+# Optional: configure LangSmith endpoints
+LANGCHAIN_ENDPOINT=https://api.smith.langchain.com
+LANGSMITH_ENDPOINT=https://api.smith.langchain.com


### PR DESCRIPTION
## Summary
- provide `.env.example` with placeholders for OpenAI and LangSmith integration

## Testing
- `uv sync`
- `pytest tests/` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_68644e80e738832ba72dab453d171f5d