### PR TITLE
Fix state handling and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A parallel task execution framework built on LangGraph that distributes AI-power
 ## Installation
 
 ```bash
-pip install langgraph langchain-openai pydantic
+pip install langgraph langchain-core pydantic
 ```
 
 ## Usage

--- a/src/state_manager.py
+++ b/src/state_manager.py
@@ -13,7 +13,12 @@ class StateManager:
             for task in state.execution_waves.waves[state.current_wave - 1]:
                 node_allocated = task.node_allocated
                 node = self.worker_manager.workers_nodes[node_allocated]
-                result = getattr(state, node.state_placeholder).messages[-1].content
+                placeholder_value = getattr(state, node.state_placeholder)
+                if hasattr(placeholder_value, "messages"):
+                    message = placeholder_value.messages[-1]
+                else:
+                    message = placeholder_value
+                result = message.content if hasattr(message, "content") else str(message)
                 updated_task_results[task.task] = result
         else:
             updated_task_results = state.task_results

--- a/src/wave_orchestrator.py
+++ b/src/wave_orchestrator.py
@@ -27,7 +27,7 @@ class WaveOrchestrator:
         def answering_node(state: any):
             results = state.task_results
             system_prompt = f"""
-    You are an expert of answering user questions based on the results of the research that was done by the workers.
+    You are an expert at answering user questions based on the results of the research that was done by the workers.
     here are the user questions and the results of the tasks:
     user_question: {state.messages[-1].content}
     task_results: {json.dumps(results)}

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -43,6 +43,23 @@ def test_prepare_command_output_subsequent_wave():
     assert out["current_wave"] == 2
     assert out["task_results"] == {"t1": "task"}
 
+
+def test_prepare_command_output_with_human_message_placeholder():
+    wm = WorkerManager()
+    node = WorkerNode(function=dummy_func, model=None, state_placeholder="s1", description="d", name="n1")
+    wm.add_node(node)
+    sm = StateManager(wm)
+    exec_waves = ExecutionWaves(waves={0: [TaskPlan(task_id="1", task="t1", node_allocated="n1")]})
+    state = type("S", (), {
+        "current_wave": 1,
+        "task_results": {},
+        "execution_waves": exec_waves,
+        "s1": HumanMessage(content="result"),
+    })()
+    out = sm.prepare_command_output(state)
+    assert out["current_wave"] == 2
+    assert out["task_results"] == {"t1": "result"}
+
 def test_create_dynamic_state():
     wm, node = setup_manager()
     sm = StateManager(wm)


### PR DESCRIPTION
## Summary
- fix grammar of answering node prompt
- ensure `prepare_command_output` works with message placeholders
- document using `langchain-core` in README
- test `prepare_command_output` with a `HumanMessage` placeholder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68641b5a0da0832bba4fc9989ad1c276